### PR TITLE
`/ip`, riptide undead fix, disabled commands in config

### DIFF
--- a/src/main/java/com/commandgeek/GeekSMP/Main.java
+++ b/src/main/java/com/commandgeek/GeekSMP/Main.java
@@ -35,10 +35,11 @@ public class Main extends JavaPlugin {
     public static FileConfiguration linked;
     public static FileConfiguration locked;
     public static FileConfiguration trusted;
-//    public static FileConfiguration pets;
+//  public static FileConfiguration pets;
 
     public static List<String> bannedWords;
     public static List<String> lockableBlocks;
+    public static List<String> disabledCommands;
 
     public static DiscordApi discordAPI;
     public static ProtocolManager protocolManager;
@@ -98,8 +99,9 @@ public class Main extends JavaPlugin {
         Setup.registerCommand("trust", new CommandTrust(), new TabTrust());
         Setup.registerCommand("trustlist", new CommandTrustList(), new TabEmpty());
         Setup.registerCommand("untrust", new CommandUntrust(), new TabUntrust());
-//        Setup.registerCommand("pet", new CommandPet(), new TabPet());
+//      Setup.registerCommand("pet", new CommandPet(), new TabPet());
         Setup.registerCommand("inspect", new CommandInspect(), new TabEmpty());
+        Setup.registerCommand("ip", new CommandIP(), new TabPlayer());
         Setup.registerCommand("afk", new CommandAfk(), new TabEmpty());
         Setup.registerCommand("reason", new CommandReason(), new TabOfflinePlayer());
 
@@ -115,7 +117,7 @@ public class Main extends JavaPlugin {
         ConfigManager.createData("linked.yml");
         ConfigManager.createData("locked.yml");
         ConfigManager.createData("trusted.yml");
-//        ConfigManager.createData("pets.yml");
+//      ConfigManager.createData("pets.yml");
 
         Main.config = ConfigManager.loadConfig("config.yml");
         Main.messages = ConfigManager.loadConfig("messages.yml");
@@ -128,7 +130,7 @@ public class Main extends JavaPlugin {
         Main.linked = ConfigManager.loadData("linked.yml");
         Main.locked = ConfigManager.loadData("locked.yml");
         Main.trusted = ConfigManager.loadData("trusted.yml");
-//        Main.pets = ConfigManager.loadData("pets.yml");
+//      Main.pets = ConfigManager.loadData("pets.yml");
 
         // Register Events
         Bukkit.getServer().getPluginManager().registerEvents(new EventListener(), this);

--- a/src/main/java/com/commandgeek/GeekSMP/Setup.java
+++ b/src/main/java/com/commandgeek/GeekSMP/Setup.java
@@ -47,6 +47,7 @@ public class Setup {
 
         Main.bannedWords = Main.config.getStringList("settings.banned-words");
         Main.lockableBlocks = Main.config.getStringList("settings.lockable-blocks");
+        Main.disabledCommands = Main.config.getStringList("settings.disabled-commands");
 
         LockManager.check();
 

--- a/src/main/java/com/commandgeek/GeekSMP/commands/CommandAfk.java
+++ b/src/main/java/com/commandgeek/GeekSMP/commands/CommandAfk.java
@@ -10,7 +10,7 @@ import org.bukkit.entity.Player;
 import java.util.HashMap;
 
 public class CommandAfk implements CommandExecutor {
-    public HashMap<String, Long> cooldowns = new HashMap<String, Long>();
+    public HashMap<String, Long> cooldowns = new HashMap<>();
     public boolean onCommand(CommandSender sender, Command cmd, String label, String[] args) {
         if (!(sender instanceof Player player)) {
             new MessageManager("console-forbidden").send(sender);
@@ -33,15 +33,6 @@ public class CommandAfk implements CommandExecutor {
         }
         // No cooldown found or cooldown has expired, save new cooldown
         cooldowns.put(sender.getName(), System.currentTimeMillis());
-        if (!(sender instanceof Player)) {
-            new MessageManager("console-forbidden").send(sender);
-            return true;
-        }
-
-        if (!player.hasPermission("geeksmp.command.afk")) {
-            new MessageManager("no-permission").send(player);
-            return true;
-        }
 
         AfkManager.toggle(player);
         return true;

--- a/src/main/java/com/commandgeek/GeekSMP/commands/CommandIP.java
+++ b/src/main/java/com/commandgeek/GeekSMP/commands/CommandIP.java
@@ -1,0 +1,42 @@
+package com.commandgeek.GeekSMP.commands;
+
+import com.commandgeek.GeekSMP.managers.MessageManager;
+import com.commandgeek.GeekSMP.managers.TeamManager;
+import org.bukkit.Bukkit;
+import org.bukkit.ChatColor;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+
+public class CommandIP implements CommandExecutor {
+
+    @Override
+    public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
+        if (sender instanceof Player player && !player.hasPermission("geeksmp.command.ip") && !TeamManager.isStaff(player)) {
+            new MessageManager("no-permission").send(player);
+            return true;
+        }
+
+        if (args.length == 1) {
+            Player target = Bukkit.getPlayer(args[0]);
+            if (target == null) {
+                new MessageManager("invalid-player")
+                    .replace("%player%", args[0])
+                    .send(sender);
+                return true;
+            }
+
+            String IP = target.getAddress().getHostString();
+            sender.sendMessage("The IP of " + target.getName() + " is " + ChatColor.BOLD + IP);
+            return true;
+        } else if(sender instanceof Player player && args.length == 0) {
+            String IP = player.getAddress().getHostString();
+            sender.sendMessage("Your IP is " + ChatColor.BOLD + IP);
+            return true;
+        }
+
+        new MessageManager("invalid-arguments").send(sender);
+        return true;
+    }
+}

--- a/src/main/java/com/commandgeek/GeekSMP/commands/CommandIP.java
+++ b/src/main/java/com/commandgeek/GeekSMP/commands/CommandIP.java
@@ -28,11 +28,19 @@ public class CommandIP implements CommandExecutor {
             }
 
             String IP = target.getAddress().getHostString();
-            sender.sendMessage("The IP of " + target.getName() + " is " + ChatColor.BOLD + IP);
+            new MessageManager("ip-player")
+                    .replace("%player%", target.getName())
+                    .replace("%ip%", IP)
+                    .send(target);
+
             return true;
         } else if(sender instanceof Player player && args.length == 0) {
             String IP = player.getAddress().getHostString();
-            sender.sendMessage("Your IP is " + ChatColor.BOLD + IP);
+            new MessageManager("ip-player")
+                .replace("%player%", player.getName())
+                .replace("%ip%", IP)
+                .send(player);
+
             return true;
         }
 

--- a/src/main/java/com/commandgeek/GeekSMP/listeners/CommandListener.java
+++ b/src/main/java/com/commandgeek/GeekSMP/listeners/CommandListener.java
@@ -3,6 +3,7 @@ package com.commandgeek.GeekSMP.listeners;
 import com.commandgeek.GeekSMP.Main;
 import com.commandgeek.GeekSMP.managers.AfkManager;
 import com.commandgeek.GeekSMP.managers.MessageManager;
+import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
@@ -27,8 +28,8 @@ public class CommandListener implements Listener {
         String[] args = event.getMessage().split(" ");
         List<String> disabled = Main.disabledCommands;
 
-        String commandName = args[0].toLowerCase(Locale.ROOT).replace("/", "").replace("minecraft:", "");
-        if (disabled.contains(commandName)) {
+        String commandName = args[0].toLowerCase(Locale.ROOT).replace("minecraft:", "");
+        if (disabled.contains(commandName.replace("/", "")) || disabled.contains(commandName)) {
             new MessageManager("disabled-command").send(event.getPlayer());
             event.setCancelled(true);
         }

--- a/src/main/java/com/commandgeek/GeekSMP/listeners/CommandListener.java
+++ b/src/main/java/com/commandgeek/GeekSMP/listeners/CommandListener.java
@@ -1,5 +1,6 @@
 package com.commandgeek.GeekSMP.listeners;
 
+import com.commandgeek.GeekSMP.Main;
 import com.commandgeek.GeekSMP.managers.AfkManager;
 import com.commandgeek.GeekSMP.managers.MessageManager;
 import org.bukkit.entity.Player;
@@ -8,6 +9,8 @@ import org.bukkit.event.Listener;
 import org.bukkit.event.player.PlayerCommandPreprocessEvent;
 
 import java.util.Arrays;
+import java.util.List;
+import java.util.Locale;
 
 @SuppressWarnings({"unused"})
 public class CommandListener implements Listener {
@@ -22,29 +25,10 @@ public class CommandListener implements Listener {
         }
 
         String[] args = event.getMessage().split(" ");
-        String[] disabled = {
-            "/minecraft:help",
-            "/minecraft:list",
-            "/list",
-            "/minecraft:me",
-            "/me",
-            "/minecraft:msg",
-            "/minecraft:teammsg",
-            "/teammsg",
-            "/minecraft:tell",
-            "/tell",
-            "/minecraft:tm",
-            "/tm",
-            "/minecraft:trigger",
-            "/trigger",
-            "/minecraft:w",
-            "/w",
-            "/plugins",
-            "/bukkit:plugins"
-        };
+        List<String> disabled = Main.disabledCommands;
 
-
-        if (Arrays.asList(disabled).contains(args[0].toLowerCase())) {
+        String commandName = args[0].toLowerCase(Locale.ROOT).replace("/", "").replace("minecraft:", "");
+        if (disabled.contains(commandName)) {
             new MessageManager("disabled-command").send(event.getPlayer());
             event.setCancelled(true);
         }

--- a/src/main/java/com/commandgeek/GeekSMP/listeners/DamageListener.java
+++ b/src/main/java/com/commandgeek/GeekSMP/listeners/DamageListener.java
@@ -42,27 +42,22 @@ public class DamageListener implements Listener {
     @EventHandler
     public void onAttack(EntityDamageByEntityEvent event) {
         Entity damager = event.getDamager();
+        Entity entity = event.getEntity();
 
         if (damager instanceof Player || damager instanceof Arrow || damager instanceof Trident || damager instanceof IronGolem) {
             if (damager instanceof Arrow arrow) {
                 arrow.remove();
             }
 
-            Entity entity = event.getEntity();
             Player victim = MorphManager.getPlayer(entity);
-            if (victim != null) {
+            if (victim != null && damager.getUniqueId() != victim.getUniqueId()) {
                 victim.damage(event.getDamage(), damager);
                 event.setCancelled(true);
             }
         }
 
-        // Prevent undeads from destroying item frames
-        if (event.getEntity() instanceof ItemFrame entity && event.getDamager() instanceof Player player) {
-            if(TeamManager.isUndead(player)) event.setCancelled(true);
-        }
-        
-        // Prevent undeads from destroying armor stands
-        if (event.getEntity() instanceof ArmorStand entity && event.getDamager() instanceof Player player) {
+        // Prevent undeads from destroying item frames or armorstands
+        if ((entity instanceof ItemFrame || entity instanceof ArmorStand) && damager instanceof Player player) {
             if(TeamManager.isUndead(player)) event.setCancelled(true);
         }
     }

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -93,7 +93,8 @@ settings:
     - "w"
     - "plugins"
     - "bukkit:plugins"
-    - "plwhere "
+    - "pl"
+    - "bukkit:pl"
 
 # - Groups -
 # All groups on the server.

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -93,6 +93,7 @@ settings:
     - "w"
     - "plugins"
     - "bukkit:plugins"
+    - "plwhere "
 
 # - Groups -
 # All groups on the server.

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -81,6 +81,19 @@ settings:
     - "heavy_weighted_pressure_plate"
     - "light_weighted_pressure_plate"
 
+  disabled-commands:
+    - "help"
+    - "list"
+    - "me"
+    - "msg"
+    - "teammsg"
+    - "tell"
+    - "tm"
+    - "trigger"
+    - "w"
+    - "plugins"
+    - "bukkit:plugins"
+
 # - Groups -
 # All groups on the server.
 # Configure each with the options below.

--- a/src/main/resources/messages.yml
+++ b/src/main/resources/messages.yml
@@ -143,6 +143,9 @@ discord-reason-ban-temporary: "**%user%** was banned for **%duration%** for \"*%
 lookup-player: "&d%player% &5is linked to &d%user%&5."
 lookup-missing: "&c%player% is not linked to a discord user."
 
+# IP Messages -
+ip-player: "The IP of %player% is %ip%"
+
 # - Failed Chat Messages -
 # %duration% - Duration of mute
 chat-forbidden: "&cYou are unable to chat."

--- a/src/main/resources/messages.yml
+++ b/src/main/resources/messages.yml
@@ -83,7 +83,14 @@ block-locked: "&c%block% &4is locked by &c%player%&4."
 
 # - Information Messages -
 player-information-header: "&d%player% information:"
-player-information-item: "&8 - &5%key%: &a%value%"
+player-information-item: "&8 - &5%key%: &a%value%"-
+ip-player: "The IP of %player% is %ip%"
+
+# - Info Messages -
+# %header% - Info header/title
+# %item% - Info item
+info-header: "&d%header%"
+info-item: "&8- &5%item%"
 
 # - Morphed Messages -
 # %morph% - Morph name
@@ -143,9 +150,6 @@ discord-reason-ban-temporary: "**%user%** was banned for **%duration%** for \"*%
 lookup-player: "&d%player% &5is linked to &d%user%&5."
 lookup-missing: "&c%player% is not linked to a discord user."
 
-# IP Messages -
-ip-player: "The IP of %player% is %ip%"
-
 # - Failed Chat Messages -
 # %duration% - Duration of mute
 chat-forbidden: "&cYou are unable to chat."
@@ -190,12 +194,6 @@ discord-mute-fail: "Could not fetch linked account, so **%user%** was muted perm
 discord-invalid-duration: "Invalid Duration."
 discord-unmute: "**%user%** has been unmuted.\nLinked: *%player% (%uuid%)*"
 discord-unmute-fail: "Could not fetch linked account, so **%user%** was unmuted."
-
-# - Info Messages -
-# %header% - Info header/title
-# %item% - Info item
-info-header: "&d%header%"
-info-item: "&8- &5%item%"
 
 # - Change-Log Messages -
 # %version% - Plugin version

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -91,10 +91,12 @@ commands:
     aliases: []
   untrust:
     aliases: []
-#  pet:
-#    aliases: []
+# pet:
+#   aliases: []
   inspect:
     aliases: [i]
+  ip:
+    aliases: []
   afk:
     aliases: []
   reason:
@@ -184,9 +186,11 @@ permissions:
     default: true
   geeksmp.command.untrust:
     default: true
-  geeksmp.command.pet:
-    default: op
+# geeksmp.command.pet:
+#   default: op
   geeksmp.command.inspect:
+    default: op
+  geeksmp.command.ip:
     default: op
   geeksmp.command.afk:
     default: true


### PR DESCRIPTION
## Description
Tridents now work properly for undeads (no damage anymore)
Disabled commands can now be set in the config.yml (settings.disabled-commands)
/ip command added (shows public ip address of player)

## Motivation and Context
fixes #54
fixes #77
fixes #74

## How Has This Been Tested?
Local hosted server
MC Version 1.17.1, Paper

- Executed disabled commands
- Tried to riptide with a trident as an undead and revived
- Executed /ip command for myself and another player who joined

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
-  [x] My code follows the code style of this project.
- [ ] My change requires a change to [the documentation](https://github.com/commandgeek/geeksmp/wiki).
- [x] I have read the [**CONTRIBUTING**](https://github.com/commandgeek/geeksmp/blob/master/.github/CONTRIBUTING.md) document.
- [x] All new and existing tests passed.
