### PR TITLE
Update proximity speed & imports, fix #6 and `/rsmp` tab

### DIFF
--- a/src/main/java/com/commandgeek/GeekSMP/Morph.java
+++ b/src/main/java/com/commandgeek/GeekSMP/Morph.java
@@ -1,6 +1,7 @@
 package com.commandgeek.GeekSMP;
 
 import com.commandgeek.GeekSMP.managers.*;
+
 import org.bukkit.*;
 import org.bukkit.entity.*;
 import org.bukkit.inventory.ItemStack;

--- a/src/main/java/com/commandgeek/GeekSMP/Setup.java
+++ b/src/main/java/com/commandgeek/GeekSMP/Setup.java
@@ -52,12 +52,12 @@ public class Setup {
 
         LockManager.check();
 
+        updateTasks();
         updateTabMetaForAll();
         updateTeams();
         updateAllRoles();
 
         Bukkit.getScheduler().cancelTasks(Main.instance);
-        updateTasks();
         initializeMovementCheck();
     }
 

--- a/src/main/java/com/commandgeek/GeekSMP/Setup.java
+++ b/src/main/java/com/commandgeek/GeekSMP/Setup.java
@@ -2,7 +2,9 @@ package com.commandgeek.GeekSMP;
 
 import com.commandgeek.GeekSMP.managers.*;
 import com.commandgeek.GeekSMP.menus.JoinMenu;
+
 import me.clip.placeholderapi.PlaceholderAPI;
+
 import org.javacord.api.entity.user.User;
 
 import org.bukkit.*;

--- a/src/main/java/com/commandgeek/GeekSMP/Setup.java
+++ b/src/main/java/com/commandgeek/GeekSMP/Setup.java
@@ -50,15 +50,18 @@ public class Setup {
         Main.lockableBlocks = Main.config.getStringList("settings.lockable-blocks");
         Main.disabledCommands = Main.config.getStringList("settings.disabled-commands");
 
+        Bukkit.getScheduler().cancelTasks(Main.instance);
+
         LockManager.check();
+        initializeMovementCheck();
 
         updateTasks();
         updateTabMetaForAll();
         updateTeams();
         updateAllRoles();
 
-        Bukkit.getScheduler().cancelTasks(Main.instance);
-        initializeMovementCheck();
+        tabUpdate();
+        updateSetupTimer();
     }
 
     public static void updateTeams() {

--- a/src/main/java/com/commandgeek/GeekSMP/commands/CommandAfk.java
+++ b/src/main/java/com/commandgeek/GeekSMP/commands/CommandAfk.java
@@ -2,6 +2,7 @@ package com.commandgeek.GeekSMP.commands;
 
 import com.commandgeek.GeekSMP.managers.AfkManager;
 import com.commandgeek.GeekSMP.managers.MessageManager;
+
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandExecutor;
 import org.bukkit.command.CommandSender;

--- a/src/main/java/com/commandgeek/GeekSMP/commands/CommandBan.java
+++ b/src/main/java/com/commandgeek/GeekSMP/commands/CommandBan.java
@@ -4,6 +4,7 @@ import com.commandgeek.GeekSMP.managers.BanManager;
 import com.commandgeek.GeekSMP.managers.MessageManager;
 import com.commandgeek.GeekSMP.managers.NumberManager;
 import com.commandgeek.GeekSMP.managers.TeamManager;
+
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandExecutor;
 import org.bukkit.command.CommandSender;

--- a/src/main/java/com/commandgeek/GeekSMP/commands/CommandBanList.java
+++ b/src/main/java/com/commandgeek/GeekSMP/commands/CommandBanList.java
@@ -3,6 +3,7 @@ package com.commandgeek.GeekSMP.commands;
 import com.commandgeek.GeekSMP.Main;
 import com.commandgeek.GeekSMP.managers.MessageManager;
 import com.commandgeek.GeekSMP.managers.TeamManager;
+
 import org.bukkit.Bukkit;
 import org.bukkit.OfflinePlayer;
 import org.bukkit.command.Command;

--- a/src/main/java/com/commandgeek/GeekSMP/commands/CommandChangeLog.java
+++ b/src/main/java/com/commandgeek/GeekSMP/commands/CommandChangeLog.java
@@ -3,6 +3,7 @@ package com.commandgeek.GeekSMP.commands;
 import com.commandgeek.GeekSMP.managers.ChangeLogManager;
 import com.commandgeek.GeekSMP.managers.MessageManager;
 import com.commandgeek.GeekSMP.managers.TeamManager;
+
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandExecutor;
 import org.bukkit.command.CommandSender;

--- a/src/main/java/com/commandgeek/GeekSMP/commands/CommandCode.java
+++ b/src/main/java/com/commandgeek/GeekSMP/commands/CommandCode.java
@@ -2,6 +2,7 @@ package com.commandgeek.GeekSMP.commands;
 
 import com.commandgeek.GeekSMP.managers.LinkManager;
 import com.commandgeek.GeekSMP.managers.MessageManager;
+
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandExecutor;
 import org.bukkit.command.CommandSender;

--- a/src/main/java/com/commandgeek/GeekSMP/commands/CommandDie.java
+++ b/src/main/java/com/commandgeek/GeekSMP/commands/CommandDie.java
@@ -1,6 +1,7 @@
 package com.commandgeek.GeekSMP.commands;
 
 import com.commandgeek.GeekSMP.managers.MessageManager;
+
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandExecutor;
 import org.bukkit.command.CommandSender;

--- a/src/main/java/com/commandgeek/GeekSMP/commands/CommandDiscord.java
+++ b/src/main/java/com/commandgeek/GeekSMP/commands/CommandDiscord.java
@@ -1,6 +1,7 @@
 package com.commandgeek.GeekSMP.commands;
 
 import com.commandgeek.GeekSMP.managers.MessageManager;
+
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandExecutor;
 import org.bukkit.command.CommandSender;

--- a/src/main/java/com/commandgeek/GeekSMP/commands/CommandFeed.java
+++ b/src/main/java/com/commandgeek/GeekSMP/commands/CommandFeed.java
@@ -1,9 +1,8 @@
 package com.commandgeek.GeekSMP.commands;
 
 import com.commandgeek.GeekSMP.managers.MessageManager;
-import com.commandgeek.GeekSMP.managers.TeamManager;
+
 import org.bukkit.Bukkit;
-import org.bukkit.GameMode;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandExecutor;
 import org.bukkit.command.CommandSender;

--- a/src/main/java/com/commandgeek/GeekSMP/commands/CommandGma.java
+++ b/src/main/java/com/commandgeek/GeekSMP/commands/CommandGma.java
@@ -2,6 +2,7 @@ package com.commandgeek.GeekSMP.commands;
 
 import com.commandgeek.GeekSMP.managers.MessageManager;
 import com.commandgeek.GeekSMP.managers.TeamManager;
+
 import org.bukkit.Bukkit;
 import org.bukkit.GameMode;
 import org.bukkit.command.Command;

--- a/src/main/java/com/commandgeek/GeekSMP/commands/CommandGmc.java
+++ b/src/main/java/com/commandgeek/GeekSMP/commands/CommandGmc.java
@@ -2,6 +2,7 @@ package com.commandgeek.GeekSMP.commands;
 
 import com.commandgeek.GeekSMP.managers.MessageManager;
 import com.commandgeek.GeekSMP.managers.TeamManager;
+
 import org.bukkit.Bukkit;
 import org.bukkit.GameMode;
 import org.bukkit.command.Command;

--- a/src/main/java/com/commandgeek/GeekSMP/commands/CommandGms.java
+++ b/src/main/java/com/commandgeek/GeekSMP/commands/CommandGms.java
@@ -2,6 +2,7 @@ package com.commandgeek.GeekSMP.commands;
 
 import com.commandgeek.GeekSMP.managers.MessageManager;
 import com.commandgeek.GeekSMP.managers.TeamManager;
+
 import org.bukkit.Bukkit;
 import org.bukkit.GameMode;
 import org.bukkit.command.Command;

--- a/src/main/java/com/commandgeek/GeekSMP/commands/CommandGmsp.java
+++ b/src/main/java/com/commandgeek/GeekSMP/commands/CommandGmsp.java
@@ -2,6 +2,7 @@ package com.commandgeek.GeekSMP.commands;
 
 import com.commandgeek.GeekSMP.managers.MessageManager;
 import com.commandgeek.GeekSMP.managers.TeamManager;
+
 import org.bukkit.Bukkit;
 import org.bukkit.GameMode;
 import org.bukkit.command.Command;

--- a/src/main/java/com/commandgeek/GeekSMP/commands/CommandHeal.java
+++ b/src/main/java/com/commandgeek/GeekSMP/commands/CommandHeal.java
@@ -1,9 +1,8 @@
 package com.commandgeek.GeekSMP.commands;
 
 import com.commandgeek.GeekSMP.managers.MessageManager;
-import com.commandgeek.GeekSMP.managers.TeamManager;
+
 import org.bukkit.Bukkit;
-import org.bukkit.GameMode;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandExecutor;
 import org.bukkit.command.CommandSender;

--- a/src/main/java/com/commandgeek/GeekSMP/commands/CommandHelp.java
+++ b/src/main/java/com/commandgeek/GeekSMP/commands/CommandHelp.java
@@ -2,6 +2,7 @@ package com.commandgeek.GeekSMP.commands;
 
 import com.commandgeek.GeekSMP.Main;
 import com.commandgeek.GeekSMP.managers.MessageManager;
+
 import org.apache.commons.lang.WordUtils;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandExecutor;

--- a/src/main/java/com/commandgeek/GeekSMP/commands/CommandIP.java
+++ b/src/main/java/com/commandgeek/GeekSMP/commands/CommandIP.java
@@ -2,8 +2,8 @@ package com.commandgeek.GeekSMP.commands;
 
 import com.commandgeek.GeekSMP.managers.MessageManager;
 import com.commandgeek.GeekSMP.managers.TeamManager;
+
 import org.bukkit.Bukkit;
-import org.bukkit.ChatColor;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandExecutor;
 import org.bukkit.command.CommandSender;

--- a/src/main/java/com/commandgeek/GeekSMP/commands/CommandInfo.java
+++ b/src/main/java/com/commandgeek/GeekSMP/commands/CommandInfo.java
@@ -2,6 +2,7 @@ package com.commandgeek.GeekSMP.commands;
 
 import com.commandgeek.GeekSMP.Main;
 import com.commandgeek.GeekSMP.managers.MessageManager;
+
 import org.apache.commons.lang.WordUtils;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandExecutor;

--- a/src/main/java/com/commandgeek/GeekSMP/commands/CommandInspect.java
+++ b/src/main/java/com/commandgeek/GeekSMP/commands/CommandInspect.java
@@ -2,8 +2,7 @@ package com.commandgeek.GeekSMP.commands;
 
 import com.commandgeek.GeekSMP.managers.MessageManager;
 import com.commandgeek.GeekSMP.managers.TeamManager;
-import org.bukkit.Bukkit;
-import org.bukkit.GameMode;
+
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandExecutor;
 import org.bukkit.command.CommandSender;

--- a/src/main/java/com/commandgeek/GeekSMP/commands/CommandLookup.java
+++ b/src/main/java/com/commandgeek/GeekSMP/commands/CommandLookup.java
@@ -3,13 +3,14 @@ package com.commandgeek.GeekSMP.commands;
 import com.commandgeek.GeekSMP.managers.DiscordManager;
 import com.commandgeek.GeekSMP.managers.EntityManager;
 import com.commandgeek.GeekSMP.managers.MessageManager;
-import com.commandgeek.GeekSMP.managers.TeamManager;
+
+import org.javacord.api.entity.user.User;
+
 import org.bukkit.OfflinePlayer;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandExecutor;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
-import org.javacord.api.entity.user.User;
 
 public class CommandLookup implements CommandExecutor {
     public boolean onCommand(CommandSender sender, Command cmd, String label, String[] args) {

--- a/src/main/java/com/commandgeek/GeekSMP/commands/CommandMap.java
+++ b/src/main/java/com/commandgeek/GeekSMP/commands/CommandMap.java
@@ -1,6 +1,7 @@
 package com.commandgeek.GeekSMP.commands;
 
 import com.commandgeek.GeekSMP.managers.MessageManager;
+
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandExecutor;
 import org.bukkit.command.CommandSender;

--- a/src/main/java/com/commandgeek/GeekSMP/commands/CommandMsg.java
+++ b/src/main/java/com/commandgeek/GeekSMP/commands/CommandMsg.java
@@ -1,6 +1,7 @@
 package com.commandgeek.GeekSMP.commands;
 
 import com.commandgeek.GeekSMP.managers.*;
+
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandExecutor;
 import org.bukkit.command.CommandSender;

--- a/src/main/java/com/commandgeek/GeekSMP/commands/CommandMsgToggle.java
+++ b/src/main/java/com/commandgeek/GeekSMP/commands/CommandMsgToggle.java
@@ -2,6 +2,7 @@ package com.commandgeek.GeekSMP.commands;
 
 import com.commandgeek.GeekSMP.managers.EntityManager;
 import com.commandgeek.GeekSMP.managers.MessageManager;
+
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandExecutor;
 import org.bukkit.command.CommandSender;

--- a/src/main/java/com/commandgeek/GeekSMP/commands/CommandMute.java
+++ b/src/main/java/com/commandgeek/GeekSMP/commands/CommandMute.java
@@ -1,6 +1,7 @@
 package com.commandgeek.GeekSMP.commands;
 
 import com.commandgeek.GeekSMP.managers.*;
+
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandExecutor;
 import org.bukkit.command.CommandSender;

--- a/src/main/java/com/commandgeek/GeekSMP/commands/CommandMuteList.java
+++ b/src/main/java/com/commandgeek/GeekSMP/commands/CommandMuteList.java
@@ -3,6 +3,7 @@ package com.commandgeek.GeekSMP.commands;
 import com.commandgeek.GeekSMP.Main;
 import com.commandgeek.GeekSMP.managers.MessageManager;
 import com.commandgeek.GeekSMP.managers.TeamManager;
+
 import org.bukkit.Bukkit;
 import org.bukkit.OfflinePlayer;
 import org.bukkit.command.Command;

--- a/src/main/java/com/commandgeek/GeekSMP/commands/CommandPet.java
+++ b/src/main/java/com/commandgeek/GeekSMP/commands/CommandPet.java
@@ -2,6 +2,7 @@
 
 import com.commandgeek.GeekSMP.Main;
 import com.commandgeek.GeekSMP.managers.*;
+
 import org.bukkit.Bukkit;
 import org.bukkit.OfflinePlayer;
 import org.bukkit.block.Block;

--- a/src/main/java/com/commandgeek/GeekSMP/commands/CommandPlayerInfo.java
+++ b/src/main/java/com/commandgeek/GeekSMP/commands/CommandPlayerInfo.java
@@ -3,6 +3,7 @@ package com.commandgeek.GeekSMP.commands;
 import com.commandgeek.GeekSMP.managers.EntityManager;
 import com.commandgeek.GeekSMP.managers.MessageManager;
 import com.commandgeek.GeekSMP.managers.NumberManager;
+
 import org.bukkit.OfflinePlayer;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandExecutor;

--- a/src/main/java/com/commandgeek/GeekSMP/commands/CommandPurgeChat.java
+++ b/src/main/java/com/commandgeek/GeekSMP/commands/CommandPurgeChat.java
@@ -2,6 +2,7 @@ package com.commandgeek.GeekSMP.commands;
 
 import com.commandgeek.GeekSMP.managers.MessageManager;
 import com.commandgeek.GeekSMP.managers.TeamManager;
+
 import org.bukkit.Bukkit;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandExecutor;

--- a/src/main/java/com/commandgeek/GeekSMP/commands/CommandPurgeTeams.java
+++ b/src/main/java/com/commandgeek/GeekSMP/commands/CommandPurgeTeams.java
@@ -2,6 +2,7 @@ package com.commandgeek.GeekSMP.commands;
 
 import com.commandgeek.GeekSMP.managers.MessageManager;
 import com.commandgeek.GeekSMP.managers.TeamManager;
+
 import org.bukkit.Bukkit;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandExecutor;

--- a/src/main/java/com/commandgeek/GeekSMP/commands/CommandReason.java
+++ b/src/main/java/com/commandgeek/GeekSMP/commands/CommandReason.java
@@ -1,6 +1,7 @@
 package com.commandgeek.GeekSMP.commands;
 
 import com.commandgeek.GeekSMP.managers.*;
+
 import org.bukkit.OfflinePlayer;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandExecutor;

--- a/src/main/java/com/commandgeek/GeekSMP/commands/CommandReloadSmp.java
+++ b/src/main/java/com/commandgeek/GeekSMP/commands/CommandReloadSmp.java
@@ -2,6 +2,7 @@ package com.commandgeek.GeekSMP.commands;
 
 import com.commandgeek.GeekSMP.Setup;
 import com.commandgeek.GeekSMP.managers.MessageManager;
+
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandExecutor;
 import org.bukkit.command.CommandSender;

--- a/src/main/java/com/commandgeek/GeekSMP/commands/CommandReply.java
+++ b/src/main/java/com/commandgeek/GeekSMP/commands/CommandReply.java
@@ -1,6 +1,7 @@
 package com.commandgeek.GeekSMP.commands;
 
 import com.commandgeek.GeekSMP.managers.*;
+
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandExecutor;
 import org.bukkit.command.CommandSender;

--- a/src/main/java/com/commandgeek/GeekSMP/commands/CommandRevive.java
+++ b/src/main/java/com/commandgeek/GeekSMP/commands/CommandRevive.java
@@ -2,6 +2,7 @@ package com.commandgeek.GeekSMP.commands;
 
 import com.commandgeek.GeekSMP.Setup;
 import com.commandgeek.GeekSMP.managers.*;
+
 import org.bukkit.Bukkit;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandExecutor;

--- a/src/main/java/com/commandgeek/GeekSMP/commands/CommandRules.java
+++ b/src/main/java/com/commandgeek/GeekSMP/commands/CommandRules.java
@@ -2,7 +2,9 @@ package com.commandgeek.GeekSMP.commands;
 
 import com.commandgeek.GeekSMP.Main;
 import com.commandgeek.GeekSMP.managers.MessageManager;
+
 import org.apache.commons.lang.WordUtils;
+
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandExecutor;
 import org.bukkit.command.CommandSender;

--- a/src/main/java/com/commandgeek/GeekSMP/commands/CommandSeeInv.java
+++ b/src/main/java/com/commandgeek/GeekSMP/commands/CommandSeeInv.java
@@ -2,6 +2,7 @@ package com.commandgeek.GeekSMP.commands;
 
 import com.commandgeek.GeekSMP.managers.MessageManager;
 import com.commandgeek.GeekSMP.managers.TeamManager;
+
 import org.bukkit.Bukkit;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandExecutor;

--- a/src/main/java/com/commandgeek/GeekSMP/commands/CommandSpy.java
+++ b/src/main/java/com/commandgeek/GeekSMP/commands/CommandSpy.java
@@ -3,6 +3,7 @@ package com.commandgeek.GeekSMP.commands;
 import com.commandgeek.GeekSMP.managers.EntityManager;
 import com.commandgeek.GeekSMP.managers.MessageManager;
 import com.commandgeek.GeekSMP.managers.TeamManager;
+
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandExecutor;
 import org.bukkit.command.CommandSender;

--- a/src/main/java/com/commandgeek/GeekSMP/commands/CommandStats.java
+++ b/src/main/java/com/commandgeek/GeekSMP/commands/CommandStats.java
@@ -3,7 +3,9 @@ package com.commandgeek.GeekSMP.commands;
 import com.commandgeek.GeekSMP.Main;
 import com.commandgeek.GeekSMP.managers.MessageManager;
 import com.commandgeek.GeekSMP.managers.TeamManager;
+
 import org.apache.commons.lang.WordUtils;
+
 import org.bukkit.ChatColor;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandExecutor;

--- a/src/main/java/com/commandgeek/GeekSMP/commands/CommandTp.java
+++ b/src/main/java/com/commandgeek/GeekSMP/commands/CommandTp.java
@@ -2,6 +2,7 @@ package com.commandgeek.GeekSMP.commands;
 
 import com.commandgeek.GeekSMP.managers.MessageManager;
 import com.commandgeek.GeekSMP.managers.TeamManager;
+
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.command.Command;

--- a/src/main/java/com/commandgeek/GeekSMP/commands/CommandTpHere.java
+++ b/src/main/java/com/commandgeek/GeekSMP/commands/CommandTpHere.java
@@ -2,6 +2,7 @@ package com.commandgeek.GeekSMP.commands;
 
 import com.commandgeek.GeekSMP.managers.MessageManager;
 import com.commandgeek.GeekSMP.managers.TeamManager;
+
 import org.bukkit.Bukkit;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandExecutor;

--- a/src/main/java/com/commandgeek/GeekSMP/commands/CommandTrack.java
+++ b/src/main/java/com/commandgeek/GeekSMP/commands/CommandTrack.java
@@ -3,6 +3,7 @@ package com.commandgeek.GeekSMP.commands;
 import com.commandgeek.GeekSMP.managers.MessageManager;
 import com.commandgeek.GeekSMP.managers.MorphManager;
 import com.commandgeek.GeekSMP.managers.TeamManager;
+
 import org.bukkit.Bukkit;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandExecutor;

--- a/src/main/java/com/commandgeek/GeekSMP/commands/CommandTrust.java
+++ b/src/main/java/com/commandgeek/GeekSMP/commands/CommandTrust.java
@@ -1,6 +1,7 @@
 package com.commandgeek.GeekSMP.commands;
 
 import com.commandgeek.GeekSMP.managers.*;
+
 import org.bukkit.OfflinePlayer;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandExecutor;

--- a/src/main/java/com/commandgeek/GeekSMP/commands/CommandTrustList.java
+++ b/src/main/java/com/commandgeek/GeekSMP/commands/CommandTrustList.java
@@ -2,8 +2,8 @@ package com.commandgeek.GeekSMP.commands;
 
 import com.commandgeek.GeekSMP.Main;
 import com.commandgeek.GeekSMP.managers.*;
+
 import org.bukkit.Bukkit;
-import org.bukkit.OfflinePlayer;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandExecutor;
 import org.bukkit.command.CommandSender;

--- a/src/main/java/com/commandgeek/GeekSMP/commands/CommandTwitch.java
+++ b/src/main/java/com/commandgeek/GeekSMP/commands/CommandTwitch.java
@@ -1,6 +1,7 @@
 package com.commandgeek.GeekSMP.commands;
 
 import com.commandgeek.GeekSMP.managers.MessageManager;
+
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandExecutor;
 import org.bukkit.command.CommandSender;

--- a/src/main/java/com/commandgeek/GeekSMP/commands/CommandUnban.java
+++ b/src/main/java/com/commandgeek/GeekSMP/commands/CommandUnban.java
@@ -3,6 +3,7 @@ package com.commandgeek.GeekSMP.commands;
 import com.commandgeek.GeekSMP.managers.BanManager;
 import com.commandgeek.GeekSMP.managers.MessageManager;
 import com.commandgeek.GeekSMP.managers.TeamManager;
+
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandExecutor;
 import org.bukkit.command.CommandSender;

--- a/src/main/java/com/commandgeek/GeekSMP/commands/CommandUnlink.java
+++ b/src/main/java/com/commandgeek/GeekSMP/commands/CommandUnlink.java
@@ -3,7 +3,7 @@ package com.commandgeek.GeekSMP.commands;
 import com.commandgeek.GeekSMP.managers.EntityManager;
 import com.commandgeek.GeekSMP.managers.LinkManager;
 import com.commandgeek.GeekSMP.managers.MessageManager;
-import org.bukkit.Bukkit;
+
 import org.bukkit.OfflinePlayer;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandExecutor;

--- a/src/main/java/com/commandgeek/GeekSMP/commands/CommandUnmute.java
+++ b/src/main/java/com/commandgeek/GeekSMP/commands/CommandUnmute.java
@@ -3,6 +3,7 @@ package com.commandgeek.GeekSMP.commands;
 import com.commandgeek.GeekSMP.managers.MessageManager;
 import com.commandgeek.GeekSMP.managers.MuteManager;
 import com.commandgeek.GeekSMP.managers.TeamManager;
+
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandExecutor;
 import org.bukkit.command.CommandSender;

--- a/src/main/java/com/commandgeek/GeekSMP/commands/CommandUnrevive.java
+++ b/src/main/java/com/commandgeek/GeekSMP/commands/CommandUnrevive.java
@@ -4,6 +4,7 @@ import com.commandgeek.GeekSMP.managers.MessageManager;
 import com.commandgeek.GeekSMP.managers.MorphManager;
 import com.commandgeek.GeekSMP.managers.TeamManager;
 import com.commandgeek.GeekSMP.menus.JoinMenu;
+
 import org.bukkit.Bukkit;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandExecutor;

--- a/src/main/java/com/commandgeek/GeekSMP/commands/CommandUntrust.java
+++ b/src/main/java/com/commandgeek/GeekSMP/commands/CommandUntrust.java
@@ -1,6 +1,7 @@
 package com.commandgeek.GeekSMP.commands;
 
 import com.commandgeek.GeekSMP.managers.*;
+
 import org.bukkit.OfflinePlayer;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandExecutor;

--- a/src/main/java/com/commandgeek/GeekSMP/commands/TabPet.java
+++ b/src/main/java/com/commandgeek/GeekSMP/commands/TabPet.java
@@ -2,6 +2,7 @@
 
 import com.commandgeek.GeekSMP.Main;
 import com.commandgeek.GeekSMP.managers.MorphManager;
+
 import org.bukkit.Bukkit;
 import org.bukkit.OfflinePlayer;
 import org.bukkit.command.Command;

--- a/src/main/java/com/commandgeek/GeekSMP/commands/TabTrack.java
+++ b/src/main/java/com/commandgeek/GeekSMP/commands/TabTrack.java
@@ -1,6 +1,7 @@
 package com.commandgeek.GeekSMP.commands;
 
 import com.commandgeek.GeekSMP.managers.TeamManager;
+
 import org.bukkit.Bukkit;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandSender;

--- a/src/main/java/com/commandgeek/GeekSMP/commands/TabTrust.java
+++ b/src/main/java/com/commandgeek/GeekSMP/commands/TabTrust.java
@@ -1,6 +1,7 @@
 package com.commandgeek.GeekSMP.commands;
 
 import com.commandgeek.GeekSMP.Main;
+
 import org.bukkit.Bukkit;
 import org.bukkit.OfflinePlayer;
 import org.bukkit.command.Command;

--- a/src/main/java/com/commandgeek/GeekSMP/commands/TabUnban.java
+++ b/src/main/java/com/commandgeek/GeekSMP/commands/TabUnban.java
@@ -1,6 +1,7 @@
 package com.commandgeek.GeekSMP.commands;
 
 import com.commandgeek.GeekSMP.Main;
+
 import org.bukkit.Bukkit;
 import org.bukkit.OfflinePlayer;
 import org.bukkit.command.Command;

--- a/src/main/java/com/commandgeek/GeekSMP/commands/TabUnmute.java
+++ b/src/main/java/com/commandgeek/GeekSMP/commands/TabUnmute.java
@@ -1,6 +1,7 @@
 package com.commandgeek.GeekSMP.commands;
 
 import com.commandgeek.GeekSMP.Main;
+
 import org.bukkit.Bukkit;
 import org.bukkit.OfflinePlayer;
 import org.bukkit.command.Command;

--- a/src/main/java/com/commandgeek/GeekSMP/commands/TabUntrust.java
+++ b/src/main/java/com/commandgeek/GeekSMP/commands/TabUntrust.java
@@ -1,6 +1,7 @@
 package com.commandgeek.GeekSMP.commands;
 
 import com.commandgeek.GeekSMP.Main;
+
 import org.bukkit.Bukkit;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandSender;

--- a/src/main/java/com/commandgeek/GeekSMP/listeners/BlockListener.java
+++ b/src/main/java/com/commandgeek/GeekSMP/listeners/BlockListener.java
@@ -1,6 +1,7 @@
 package com.commandgeek.GeekSMP.listeners;
 
 import com.commandgeek.GeekSMP.managers.LockManager;
+
 import org.bukkit.block.Block;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;

--- a/src/main/java/com/commandgeek/GeekSMP/listeners/ChatListener.java
+++ b/src/main/java/com/commandgeek/GeekSMP/listeners/ChatListener.java
@@ -2,6 +2,7 @@ package com.commandgeek.GeekSMP.listeners;
 
 import com.commandgeek.GeekSMP.Main;
 import com.commandgeek.GeekSMP.managers.*;
+
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;

--- a/src/main/java/com/commandgeek/GeekSMP/listeners/CommandListener.java
+++ b/src/main/java/com/commandgeek/GeekSMP/listeners/CommandListener.java
@@ -3,13 +3,12 @@ package com.commandgeek.GeekSMP.listeners;
 import com.commandgeek.GeekSMP.Main;
 import com.commandgeek.GeekSMP.managers.AfkManager;
 import com.commandgeek.GeekSMP.managers.MessageManager;
-import org.bukkit.Bukkit;
+
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.player.PlayerCommandPreprocessEvent;
 
-import java.util.Arrays;
 import java.util.List;
 import java.util.Locale;
 

--- a/src/main/java/com/commandgeek/GeekSMP/listeners/DamageListener.java
+++ b/src/main/java/com/commandgeek/GeekSMP/listeners/DamageListener.java
@@ -4,6 +4,7 @@ import com.commandgeek.GeekSMP.Main;
 import com.commandgeek.GeekSMP.managers.MorphManager;
 import com.commandgeek.GeekSMP.managers.PacketManager;
 import com.commandgeek.GeekSMP.managers.TeamManager;
+
 import org.bukkit.Bukkit;
 import org.bukkit.Sound;
 import org.bukkit.entity.*;

--- a/src/main/java/com/commandgeek/GeekSMP/listeners/DeathListener.java
+++ b/src/main/java/com/commandgeek/GeekSMP/listeners/DeathListener.java
@@ -2,6 +2,7 @@ package com.commandgeek.GeekSMP.listeners;
 
 import com.commandgeek.GeekSMP.Setup;
 import com.commandgeek.GeekSMP.managers.*;
+
 import org.bukkit.Bukkit;
 import org.bukkit.Particle;
 import org.bukkit.Sound;

--- a/src/main/java/com/commandgeek/GeekSMP/listeners/DeathListener.java
+++ b/src/main/java/com/commandgeek/GeekSMP/listeners/DeathListener.java
@@ -29,7 +29,8 @@ public class DeathListener implements Listener {
 
                 Bukkit.broadcastMessage(new MessageManager("revive").replace("%player%", killer.getName()).replace("%victim%", player.getName()).string());
                 event.setDeathMessage(null);
-                for (Player online : Bukkit.getOnlinePlayers()) online.playSound(online.getLocation(), Sound.ENTITY_ZOMBIE_VILLAGER_CURE, 1, 2);
+                player.playSound(player.getLocation(), Sound.ENTITY_ZOMBIE_VILLAGER_CURE, 1, 1);
+                killer.playSound(killer.getLocation(), Sound.ENTITY_ZOMBIE_VILLAGER_CURE, 1, 1);
                 return;
             }
         }

--- a/src/main/java/com/commandgeek/GeekSMP/listeners/EventListener.java
+++ b/src/main/java/com/commandgeek/GeekSMP/listeners/EventListener.java
@@ -3,6 +3,7 @@ package com.commandgeek.GeekSMP.listeners;
 import com.commandgeek.GeekSMP.Main;
 import com.commandgeek.GeekSMP.Setup;
 import com.commandgeek.GeekSMP.managers.*;
+
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.Material;

--- a/src/main/java/com/commandgeek/GeekSMP/listeners/InteractListener.java
+++ b/src/main/java/com/commandgeek/GeekSMP/listeners/InteractListener.java
@@ -2,6 +2,7 @@ package com.commandgeek.GeekSMP.listeners;
 
 import com.commandgeek.GeekSMP.Main;
 import com.commandgeek.GeekSMP.managers.*;
+
 import org.bukkit.Bukkit;
 import org.bukkit.Material;
 import org.bukkit.OfflinePlayer;

--- a/src/main/java/com/commandgeek/GeekSMP/listeners/InventoryListener.java
+++ b/src/main/java/com/commandgeek/GeekSMP/listeners/InventoryListener.java
@@ -5,6 +5,7 @@ import com.commandgeek.GeekSMP.managers.MessageManager;
 import com.commandgeek.GeekSMP.managers.MorphManager;
 import com.commandgeek.GeekSMP.managers.TeamManager;
 import com.commandgeek.GeekSMP.menus.JoinMenu;
+
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;

--- a/src/main/java/com/commandgeek/GeekSMP/listeners/ItemListener.java
+++ b/src/main/java/com/commandgeek/GeekSMP/listeners/ItemListener.java
@@ -2,6 +2,7 @@ package com.commandgeek.GeekSMP.listeners;
 
 import com.commandgeek.GeekSMP.managers.MorphManager;
 import com.commandgeek.GeekSMP.managers.TeamManager;
+
 import org.bukkit.Material;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;

--- a/src/main/java/com/commandgeek/GeekSMP/listeners/JoinListener.java
+++ b/src/main/java/com/commandgeek/GeekSMP/listeners/JoinListener.java
@@ -3,6 +3,7 @@ package com.commandgeek.GeekSMP.listeners;
 import com.commandgeek.GeekSMP.Main;
 import com.commandgeek.GeekSMP.Setup;
 import com.commandgeek.GeekSMP.managers.*;
+
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.GameMode;

--- a/src/main/java/com/commandgeek/GeekSMP/listeners/MoveListener.java
+++ b/src/main/java/com/commandgeek/GeekSMP/listeners/MoveListener.java
@@ -2,6 +2,7 @@ package com.commandgeek.GeekSMP.listeners;
 
 import com.commandgeek.GeekSMP.Main;
 import com.commandgeek.GeekSMP.managers.*;
+
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;

--- a/src/main/java/com/commandgeek/GeekSMP/listeners/MoveListener.java
+++ b/src/main/java/com/commandgeek/GeekSMP/listeners/MoveListener.java
@@ -28,8 +28,8 @@ public class MoveListener implements Listener {
         if (TeamManager.isUndead(player)) {
             if (!MorphManager.isMorphedPlayer(player)) {
                 event.setCancelled(true);
-            } else if (!EntityManager.isPlayerNear(player.getLocation(), 100)) {
-                player.addPotionEffect(new PotionEffect(PotionEffectType.SPEED, 1000000, 4, true, false, false));
+            } else if (!EntityManager.isPlayerNear(player.getLocation(), 50)) {
+                player.addPotionEffect(new PotionEffect(PotionEffectType.SPEED, 1000000, 2, true, false, false));
             } else {
                 player.removePotionEffect(PotionEffectType.SPEED);
             }

--- a/src/main/java/com/commandgeek/GeekSMP/listeners/QuitListener.java
+++ b/src/main/java/com/commandgeek/GeekSMP/listeners/QuitListener.java
@@ -3,6 +3,7 @@ package com.commandgeek.GeekSMP.listeners;
 import com.commandgeek.GeekSMP.Main;
 import com.commandgeek.GeekSMP.Setup;
 import com.commandgeek.GeekSMP.managers.*;
+
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;

--- a/src/main/java/com/commandgeek/GeekSMP/listeners/discord/DiscordMessageCreateListener.java
+++ b/src/main/java/com/commandgeek/GeekSMP/listeners/discord/DiscordMessageCreateListener.java
@@ -4,17 +4,19 @@ package com.commandgeek.GeekSMP.listeners.discord;
 import com.commandgeek.GeekSMP.Main;
 import com.commandgeek.GeekSMP.Setup;
 import com.commandgeek.GeekSMP.managers.*;
-import org.bukkit.Bukkit;
-import org.bukkit.OfflinePlayer;
-import org.bukkit.command.CommandSender;
-import org.bukkit.entity.Player;
-import org.bukkit.scheduler.BukkitRunnable;
+
 import org.javacord.api.entity.channel.TextChannel;
 import org.javacord.api.entity.message.Message;
 import org.javacord.api.entity.permission.PermissionType;
 import org.javacord.api.entity.user.User;
 import org.javacord.api.event.message.MessageCreateEvent;
 import org.javacord.api.listener.message.MessageCreateListener;
+
+import org.bukkit.Bukkit;
+import org.bukkit.OfflinePlayer;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+import org.bukkit.scheduler.BukkitRunnable;
 
 import java.util.List;
 import java.util.UUID;

--- a/src/main/java/com/commandgeek/GeekSMP/managers/BanManager.java
+++ b/src/main/java/com/commandgeek/GeekSMP/managers/BanManager.java
@@ -2,6 +2,7 @@ package com.commandgeek.GeekSMP.managers;
 
 import com.commandgeek.GeekSMP.Main;
 import com.commandgeek.GeekSMP.Setup;
+
 import org.bukkit.OfflinePlayer;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;

--- a/src/main/java/com/commandgeek/GeekSMP/managers/ChangeLogManager.java
+++ b/src/main/java/com/commandgeek/GeekSMP/managers/ChangeLogManager.java
@@ -1,8 +1,10 @@
 package com.commandgeek.GeekSMP.managers;
 
 import com.commandgeek.GeekSMP.ChangeLog;
-import org.bukkit.command.CommandSender;
+
 import org.javacord.api.entity.message.embed.EmbedBuilder;
+
+import org.bukkit.command.CommandSender;
 
 import java.awt.*;
 import java.util.HashMap;

--- a/src/main/java/com/commandgeek/GeekSMP/managers/ChatManager.java
+++ b/src/main/java/com/commandgeek/GeekSMP/managers/ChatManager.java
@@ -1,6 +1,7 @@
 package com.commandgeek.GeekSMP.managers;
 
 import com.commandgeek.GeekSMP.Main;
+
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.entity.Player;

--- a/src/main/java/com/commandgeek/GeekSMP/managers/ConfigManager.java
+++ b/src/main/java/com/commandgeek/GeekSMP/managers/ConfigManager.java
@@ -1,6 +1,7 @@
 package com.commandgeek.GeekSMP.managers;
 
 import com.commandgeek.GeekSMP.Main;
+
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.World;

--- a/src/main/java/com/commandgeek/GeekSMP/managers/DiscordManager.java
+++ b/src/main/java/com/commandgeek/GeekSMP/managers/DiscordManager.java
@@ -1,17 +1,19 @@
 package com.commandgeek.GeekSMP.managers;
 
 import com.commandgeek.GeekSMP.Main;
-import org.bukkit.Bukkit;
-import org.bukkit.OfflinePlayer;
-import org.bukkit.configuration.ConfigurationSection;
-import org.bukkit.configuration.file.FileConfiguration;
-import org.bukkit.entity.Player;
+
 import org.javacord.api.entity.channel.TextChannel;
 import org.javacord.api.entity.message.Message;
 import org.javacord.api.entity.message.embed.EmbedBuilder;
 import org.javacord.api.entity.permission.Role;
 import org.javacord.api.entity.server.Server;
 import org.javacord.api.entity.user.User;
+
+import org.bukkit.Bukkit;
+import org.bukkit.OfflinePlayer;
+import org.bukkit.configuration.ConfigurationSection;
+import org.bukkit.configuration.file.FileConfiguration;
+import org.bukkit.entity.Player;
 
 import java.awt.*;
 import java.util.ArrayList;

--- a/src/main/java/com/commandgeek/GeekSMP/managers/EntityManager.java
+++ b/src/main/java/com/commandgeek/GeekSMP/managers/EntityManager.java
@@ -1,6 +1,7 @@
 package com.commandgeek.GeekSMP.managers;
 
 import com.commandgeek.GeekSMP.Main;
+
 import org.bukkit.*;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.EntityType;

--- a/src/main/java/com/commandgeek/GeekSMP/managers/ItemManager.java
+++ b/src/main/java/com/commandgeek/GeekSMP/managers/ItemManager.java
@@ -3,6 +3,7 @@ package com.commandgeek.GeekSMP.managers;
 
 import com.mojang.authlib.GameProfile;
 import com.mojang.authlib.properties.Property;
+
 import org.bukkit.ChatColor;
 import org.bukkit.Material;
 import org.bukkit.enchantments.Enchantment;

--- a/src/main/java/com/commandgeek/GeekSMP/managers/LinkManager.java
+++ b/src/main/java/com/commandgeek/GeekSMP/managers/LinkManager.java
@@ -2,10 +2,12 @@ package com.commandgeek.GeekSMP.managers;
 
 import com.commandgeek.GeekSMP.Main;
 import com.commandgeek.GeekSMP.Setup;
-import org.bukkit.Bukkit;
-import org.bukkit.entity.Player;
+
 import org.javacord.api.entity.server.Server;
 import org.javacord.api.entity.user.User;
+
+import org.bukkit.Bukkit;
+import org.bukkit.entity.Player;
 
 import java.util.HashMap;
 import java.util.Map;

--- a/src/main/java/com/commandgeek/GeekSMP/managers/LockManager.java
+++ b/src/main/java/com/commandgeek/GeekSMP/managers/LockManager.java
@@ -1,7 +1,9 @@
 package com.commandgeek.GeekSMP.managers;
 
 import com.commandgeek.GeekSMP.Main;
+
 import org.apache.commons.lang.WordUtils;
+
 import org.bukkit.*;
 import org.bukkit.block.Block;
 import org.bukkit.block.Chest;

--- a/src/main/java/com/commandgeek/GeekSMP/managers/MessageManager.java
+++ b/src/main/java/com/commandgeek/GeekSMP/managers/MessageManager.java
@@ -1,10 +1,12 @@
 package com.commandgeek.GeekSMP.managers;
 
 import com.commandgeek.GeekSMP.Main;
+
+import org.javacord.api.entity.channel.TextChannel;
+
 import org.bukkit.ChatColor;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
-import org.javacord.api.entity.channel.TextChannel;
 
 import java.util.regex.Matcher;
 

--- a/src/main/java/com/commandgeek/GeekSMP/managers/MorphManager.java
+++ b/src/main/java/com/commandgeek/GeekSMP/managers/MorphManager.java
@@ -2,8 +2,10 @@ package com.commandgeek.GeekSMP.managers;
 
 import com.commandgeek.GeekSMP.Main;
 import com.commandgeek.GeekSMP.Morph;
+
 import net.md_5.bungee.api.ChatMessageType;
 import net.md_5.bungee.api.chat.TextComponent;
+
 import org.bukkit.*;
 import org.bukkit.entity.*;
 import org.bukkit.inventory.EntityEquipment;

--- a/src/main/java/com/commandgeek/GeekSMP/managers/MorphManager.java
+++ b/src/main/java/com/commandgeek/GeekSMP/managers/MorphManager.java
@@ -10,7 +10,6 @@ import org.bukkit.inventory.EntityEquipment;
 import org.bukkit.potion.PotionEffect;
 
 import java.util.Hashtable;
-import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 

--- a/src/main/java/com/commandgeek/GeekSMP/managers/MuteManager.java
+++ b/src/main/java/com/commandgeek/GeekSMP/managers/MuteManager.java
@@ -2,6 +2,7 @@ package com.commandgeek.GeekSMP.managers;
 
 import com.commandgeek.GeekSMP.Main;
 import com.commandgeek.GeekSMP.Setup;
+
 import org.bukkit.OfflinePlayer;
 import org.bukkit.command.CommandSender;
 

--- a/src/main/java/com/commandgeek/GeekSMP/managers/PacketManager.java
+++ b/src/main/java/com/commandgeek/GeekSMP/managers/PacketManager.java
@@ -1,12 +1,14 @@
 package com.commandgeek.GeekSMP.managers;
 
 import com.commandgeek.GeekSMP.Main;
+
 import com.comphenix.protocol.PacketType;
 import com.comphenix.protocol.events.PacketContainer;
 import com.comphenix.protocol.wrappers.EnumWrappers;
 import com.comphenix.protocol.wrappers.PlayerInfoData;
 import com.comphenix.protocol.wrappers.WrappedChatComponent;
 import com.comphenix.protocol.wrappers.WrappedGameProfile;
+
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.entity.Entity;
@@ -15,7 +17,6 @@ import org.bukkit.scoreboard.Team;
 
 import java.lang.reflect.InvocationTargetException;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 

--- a/src/main/java/com/commandgeek/GeekSMP/managers/ServerManager.java
+++ b/src/main/java/com/commandgeek/GeekSMP/managers/ServerManager.java
@@ -1,9 +1,4 @@
-package com.commandgeek.GeekSMP.managers;
-
-import org.bukkit.Bukkit;
-import org.bukkit.Material;
-import org.bukkit.NamespacedKey;
-import org.bukkit.inventory.ShapedRecipe;
+/*package com.commandgeek.GeekSMP.managers;
 
 public class ServerManager implements Runnable {
 
@@ -36,4 +31,4 @@ public class ServerManager implements Runnable {
         TICKS[(TICK_COUNT % TICKS.length)] = System.currentTimeMillis();
         TICK_COUNT += 1;
     }
-}
+}*/

--- a/src/main/java/com/commandgeek/GeekSMP/managers/TeamManager.java
+++ b/src/main/java/com/commandgeek/GeekSMP/managers/TeamManager.java
@@ -2,6 +2,7 @@ package com.commandgeek.GeekSMP.managers;
 
 import com.commandgeek.GeekSMP.Main;
 import com.commandgeek.GeekSMP.Setup;
+
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.configuration.ConfigurationSection;

--- a/src/main/java/com/commandgeek/GeekSMP/menus/JoinMenu.java
+++ b/src/main/java/com/commandgeek/GeekSMP/menus/JoinMenu.java
@@ -4,6 +4,7 @@ import com.commandgeek.GeekSMP.Main;
 import com.commandgeek.GeekSMP.Morph;
 import com.commandgeek.GeekSMP.managers.InventoryManager;
 import com.commandgeek.GeekSMP.managers.ItemManager;
+
 import org.bukkit.Material;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.Inventory;


### PR DESCRIPTION
## Description
- Proximity speed for undeads will now be given when another player is not a radius of 50 blocks (instead of 100) and will only get speed 3 instead of 5.
- Revive sound will now only be heard by the killer and the killed.
- `/rsmp` will no longer break placeholders in tab

Co-authored by: @DWAA1660 

## Motivation and Context
Fixes #6

## How Has This Been Tested?
Tested on a test server on Java 1.17.1, Paper

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to [the documentation](https://github.com/commandgeek/geeksmp/wiki).
- [x] I have read the [**CONTRIBUTING**](https://github.com/commandgeek/geeksmp/blob/master/.github/CONTRIBUTING.md) document.
- [x] All new and existing tests passed.
