### PR TITLE
Fix #36 & remove `minecraft:` replace

### DIFF
--- a/src/main/java/com/commandgeek/GeekSMP/Main.java
+++ b/src/main/java/com/commandgeek/GeekSMP/Main.java
@@ -107,6 +107,7 @@ public class Main extends JavaPlugin {
         Setup.registerCommand("ip", new CommandIP(), new TabPlayer());
         Setup.registerCommand("afk", new CommandAfk(), new TabEmpty());
         Setup.registerCommand("reason", new CommandReason(), new TabOfflinePlayer());
+        Setup.registerCommand("bypass", new CommandBypass(), new TabEmpty());
 
         // Create Files
         ConfigManager.createDefaultConfig("config.yml");

--- a/src/main/java/com/commandgeek/GeekSMP/commands/CommandBypass.java
+++ b/src/main/java/com/commandgeek/GeekSMP/commands/CommandBypass.java
@@ -1,0 +1,26 @@
+package com.commandgeek.GeekSMP.commands;
+
+import com.commandgeek.GeekSMP.managers.BypassManager;
+import com.commandgeek.GeekSMP.managers.MessageManager;
+
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+
+public class CommandBypass implements CommandExecutor {
+    public boolean onCommand(CommandSender sender, Command cmd, String label, String[] args) {
+        if (!(sender instanceof Player player)) {
+            new MessageManager("console-forbidden").send(sender);
+            return true;
+        }
+
+        if (!player.hasPermission("geeksmp.command.bypass")) {
+            new MessageManager("no-permission").send(player);
+            return true;
+        }
+
+        BypassManager.toggle(player);
+        return true;
+    }
+}

--- a/src/main/java/com/commandgeek/GeekSMP/listeners/CommandListener.java
+++ b/src/main/java/com/commandgeek/GeekSMP/listeners/CommandListener.java
@@ -27,7 +27,7 @@ public class CommandListener implements Listener {
         String[] args = event.getMessage().split(" ");
         List<String> disabled = Main.disabledCommands;
 
-        String commandName = args[0].toLowerCase(Locale.ROOT).replace("minecraft:", "");
+        String commandName = args[0].toLowerCase(Locale.ROOT);
         if (disabled.contains(commandName.replace("/", "")) || disabled.contains(commandName)) {
             new MessageManager("disabled-command").send(event.getPlayer());
             event.setCancelled(true);

--- a/src/main/java/com/commandgeek/GeekSMP/listeners/InteractListener.java
+++ b/src/main/java/com/commandgeek/GeekSMP/listeners/InteractListener.java
@@ -21,6 +21,8 @@ import org.bukkit.scheduler.BukkitRunnable;
 import java.util.Objects;
 import java.util.UUID;
 
+import static com.commandgeek.GeekSMP.managers.BypassManager.bypass;
+
 
 @SuppressWarnings({"unused"})
 public class InteractListener implements Listener {
@@ -51,20 +53,21 @@ public class InteractListener implements Listener {
         }
 
         // Check if Locked
-        if ((!TeamManager.isStaff(player) && !player.isOp()) || !player.isSneaking())
-        if (event.getClickedBlock() != null && LockManager.isLockedForPlayer(event.getClickedBlock(), player)) {
-            String owner = Main.locked.getString(LockManager.getId(event.getClickedBlock()) + ".locked");
+        if (((!TeamManager.isStaff(player) && !player.isOp()) || !player.isSneaking()) && !bypass.contains(player)) {
+            if (event.getClickedBlock() != null && LockManager.isLockedForPlayer(event.getClickedBlock(), player)) {
+                String owner = Main.locked.getString(LockManager.getId(event.getClickedBlock()) + ".locked");
 
-            if (owner != null) {
-                OfflinePlayer op = Bukkit.getOfflinePlayer(UUID.fromString(owner));
+                if (owner != null) {
+                    OfflinePlayer op = Bukkit.getOfflinePlayer(UUID.fromString(owner));
 
-                if (!LockManager.isTrustedBy(player, op)) {
-                    event.setCancelled(true);
-                    new MessageManager("block-locked")
-                            .replace("%block%", LockManager.getName(event.getClickedBlock()))
-                            .replace("%player%", Bukkit.getOfflinePlayer(UUID.fromString(Objects.requireNonNull(LockManager.getLocker(event.getClickedBlock())))).getName())
-                            .send(player);
-                    player.playSound(player.getLocation(), Sound.BLOCK_CHEST_LOCKED, 1, 2);
+                    if (!LockManager.isTrustedBy(player, op)) {
+                        event.setCancelled(true);
+                        new MessageManager("block-locked")
+                                .replace("%block%", LockManager.getName(event.getClickedBlock()))
+                                .replace("%player%", Bukkit.getOfflinePlayer(UUID.fromString(Objects.requireNonNull(LockManager.getLocker(event.getClickedBlock())))).getName())
+                                .send(player);
+                        player.playSound(player.getLocation(), Sound.BLOCK_CHEST_LOCKED, 1, 2);
+                    }
                 }
             }
         }

--- a/src/main/java/com/commandgeek/GeekSMP/managers/BypassManager.java
+++ b/src/main/java/com/commandgeek/GeekSMP/managers/BypassManager.java
@@ -1,0 +1,33 @@
+package com.commandgeek.GeekSMP.managers;
+
+import org.bukkit.entity.Player;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class BypassManager {
+
+    public static List<Player> bypass = new ArrayList<>();
+
+    public static void toggle(Player player) {
+        if (bypass.contains(player)) {
+            disable(player);
+        } else {
+            enable(player);
+        }
+    }
+
+    public static void enable(Player player) {
+        bypass.add(player);
+        new MessageManager("bypass-enabled").send(player);
+    }
+
+    public static void disable(Player player) {
+        bypass.remove(player);
+        new MessageManager("bypass-disabled").send(player);
+    }
+
+    public static boolean check(Player player) {
+        return bypass.contains(player);
+    }
+}

--- a/src/main/resources/messages.yml
+++ b/src/main/resources/messages.yml
@@ -53,7 +53,7 @@ spy-message: "&x&1&d&3&0&f&9%sender% &8to &x&1&d&3&0&f&9%receiver% &8> &9%messag
 spy-enabled: "&5Spying &denabled&5."
 spy-disabled: "&5Spying &ddisabled&5."
 
-# - Lock Messages
+# - Lock Messages -
 # %block% - Targeted block name
 # %player% - Trusted player name
 lock-success: "&5Locked &d%block%&5."
@@ -71,6 +71,10 @@ trust-list-empty: "&8 - &5&onone"
 untrust-success: "&5No longer trusting &d%player%&5."
 untrust-fail: "&c%player% isn't trusted."
 block-locked: "&c%block% &4is locked by &c%player%&4."
+
+# - Bypass Messages -
+bypass-enable: "&aLock bypass &2enabled&5."
+bypass-disable: "&cLock bypass &4disabled&5."
 
 ## - Pet Messages -
 ## %player% - Pet player name

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -101,6 +101,8 @@ commands:
     aliases: []
   reason:
     aliases: []
+  bypass:
+    aliases: []
 
 
 permissions:
@@ -195,4 +197,6 @@ permissions:
   geeksmp.command.afk:
     default: true
   geeksmp.command.reason:
+    default: op
+  geeksmp.command.bypass:
     default: op


### PR DESCRIPTION
## Description
- I made `/bypass`, while still keeping crouch-bypass
- I removed the `minecraft:` replace thing for commands to fix `/msg`

## Motivation and Context
Fixes #36 

## How Has This Been Tested?
I tested this on the GeekSMP Development server which is Paper 1.17.1.
Both changes have been tested.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to [the documentation](https://github.com/commandgeek/geeksmp/wiki).
- [x] I have read the [**CONTRIBUTING**](https://github.com/commandgeek/geeksmp/blob/master/.github/CONTRIBUTING.md) document.
- [x] All new and existing tests passed.