### PR TITLE
Fix markdown escaping not working

### DIFF
--- a/src/main/java/com/commandgeek/GeekSMP/listeners/QuitListener.java
+++ b/src/main/java/com/commandgeek/GeekSMP/listeners/QuitListener.java
@@ -32,7 +32,7 @@ public class QuitListener implements Listener {
         }
         event.setQuitMessage(new MessageManager("leave").replace("%player%", player.getName()).string());
         new MessageManager("smp-chat-leave")
-                .replace("%player%", player.getName())
+                .replace("%player%", player.getName(), true)
                 .sendDiscord(DiscordManager.smpChatChannel);
     }
 

--- a/src/main/java/com/commandgeek/GeekSMP/managers/MessageManager.java
+++ b/src/main/java/com/commandgeek/GeekSMP/managers/MessageManager.java
@@ -28,7 +28,7 @@ public class MessageManager {
             replacement = replacement.replaceAll(mdRegex, Matcher.quoteReplacement("\\")+"$0");
         }
 
-        message = message.replaceAll(regex, replacement);
+        message = message.replaceAll(regex, Matcher.quoteReplacement(replacement));
         return this;
     }
 


### PR DESCRIPTION
## Description
Fixed escapeMarkdown parameter in replace method (ChatManager) not escaping the markdown correctly

## Motivation and Context
fixes #41 

## How Has This Been Tested?
Local Server, 1.18.1
I set the escapeMarkdown parameter to true for chat messages and sent messages that included markdown

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x ] My code follows the code style of this project.
- [ ] My change requires a change to [the documentation](https://github.com/commandgeek/geeksmp/wiki).
- [x ] I have read the [**CONTRIBUTING**](https://github.com/commandgeek/geeksmp/blob/master/.github/CONTRIBUTING.md) document.
- [x ] All new and existing tests passed.
